### PR TITLE
Fix welcome avatar being too big when the user doesn't have a custom avatar

### DIFF
--- a/src/joseta/JosetaBot.java
+++ b/src/joseta/JosetaBot.java
@@ -25,6 +25,7 @@ public class JosetaBot {
     public static final Seq<Command> commands = Seq.with(
         new PingCommand(),
         new MultiInfoCommand(),
+        new ManualWelcomeCommand(),
 
         new AdminCommand(),
         

--- a/src/joseta/commands/misc/ManualWelcomeCommand.java
+++ b/src/joseta/commands/misc/ManualWelcomeCommand.java
@@ -1,0 +1,56 @@
+package joseta.commands.misc;
+
+import joseta.commands.Command;
+import joseta.events.WelcomeMessage;
+
+import net.dv8tion.jda.api.*;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.ChannelType;
+import net.dv8tion.jda.api.entities.channel.unions.GuildChannelUnion;
+import net.dv8tion.jda.api.events.interaction.command.*;
+import net.dv8tion.jda.api.interactions.commands.*;
+import net.dv8tion.jda.api.interactions.commands.build.*;
+
+public class ManualWelcomeCommand extends Command {
+    protected User user;
+    protected GuildChannelUnion channel;
+    
+    public ManualWelcomeCommand() {
+        super(
+            "manual-welcome",
+            "Crée un message de bienvenue manuellement.",
+            DefaultMemberPermissions.enabledFor(Permission.ADMINISTRATOR),
+            new OptionData(
+                OptionType.USER,
+                "user",
+                "L'utilisateur à accueillir.",
+                true
+            ),
+            new OptionData(
+                OptionType.CHANNEL,
+                "channel",
+                "Le salon dans lequel le message est envoyé.",
+                true
+            )
+        );
+    }
+    
+    @Override
+    protected void getArgs(SlashCommandInteractionEvent event) {
+        user = event.getOption("user") != null ? event.getOption("user").getAsUser() : null;
+        channel = event.getOption("channel") != null ? event.getOption("channel").getAsChannel() : null;
+    }
+    
+    @Override
+    public void runImpl(SlashCommandInteractionEvent event) {
+        if (channel != null && channel.getType() == ChannelType.TEXT) {
+            WelcomeMessage.sendWelcomeMessage(
+                event.getGuild(),
+                channel.asTextChannel(),
+                user
+            );
+            event.reply("Succès").setEphemeral(true).queue();
+        }
+        event.reply("Erreur: Le salon spécifié n'est pas un salon textuel.").setEphemeral(true).queue();
+    }
+}


### PR DESCRIPTION
This PR:
- Adds automatic resize of the user's avatar in the welcome message if it isn't of the right size.
- Makes some of the WelcomeMessage methods static
- Adds a command to manually send a welcome message (for instance if someone joined while the bot was down, you may wnt to manually send it)

Note: Currently, the scaling creates some strange color changes, but this is negligible.

