### PR TITLE
Use SlashCommandData directly instead of own builder

### DIFF
--- a/src/joseta/JosetaBot.java
+++ b/src/joseta/JosetaBot.java
@@ -96,7 +96,7 @@ public class JosetaBot {
     }
 
     private static void initializeCommands() {
-        SlashCommandData[] commandsData = commands.map(cmd -> cmd.build()).toArray(SlashCommandData.class);
+        SlashCommandData[] commandsData = commands.map(cmd -> cmd.getCommandData()).toArray(SlashCommandData.class);
         
         bot.getGuilds().forEach(g -> g.updateCommands().addCommands().queue()); // Reset for the guilds command to avoid duplicates.
         bot.updateCommands().addCommands(commandsData).queue();

--- a/src/joseta/commands/Command.java
+++ b/src/joseta/commands/Command.java
@@ -1,43 +1,16 @@
 package joseta.commands;
 
 import net.dv8tion.jda.api.events.interaction.command.*;
-import net.dv8tion.jda.api.interactions.*;
-import net.dv8tion.jda.api.interactions.commands.*;
 import net.dv8tion.jda.api.interactions.commands.build.*;
 
 public abstract class Command {
-    protected String name;
-    protected String description;
-    protected DefaultMemberPermissions defaultPermissions = DefaultMemberPermissions.ENABLED;
-    protected OptionData[] options = new OptionData[0];
-    protected SubcommandData[] subcommands = new SubcommandData[0];
-    protected SubcommandGroupData[] subcommandGroups = new SubcommandGroupData[0];
-    protected boolean isNSFW = false;
-    protected InteractionContextType[] contexts = new InteractionContextType[0];
-    protected IntegrationType[] integrationTypes = new IntegrationType[0];
+    protected SlashCommandData commandData;
 
-    public Command() {}
+    private Command() {}
 
     public Command(String name, String description) {
-        this.name = name;
-        this.description = description;
+        this.commandData = Commands.slash(name,description);
     }
-
-    public SlashCommandData build() {
-        SlashCommandData commandData = Commands.slash(name, description)
-            .setDefaultPermissions(defaultPermissions)
-            .addOptions(options)
-            .addSubcommands(subcommands)
-            .addSubcommandGroups(subcommandGroups)
-            .setNSFW(isNSFW);
-
-        // Those are the only one that'll throw an error if they're empty.
-        if (contexts.length > 0) commandData.setContexts(contexts);
-        if (integrationTypes.length > 0) commandData.setIntegrationTypes(integrationTypes);
-
-        return commandData;
-    }
-
 
     public final void run(SlashCommandInteractionEvent event) {
         getArgs(event);
@@ -53,103 +26,12 @@ public abstract class Command {
     protected boolean check(SlashCommandInteractionEvent event) {
         return true;
     }
-    
+
+    public SlashCommandData getCommandData() {
+        return commandData;
+    }
 
     public String getName() {
-        return name;
+        return commandData.getName();
     }
-
-    public Command setName(String name) {
-        this.name = name;
-        return this;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-
-    public Command setDescription(String description) {
-        this.description = description;
-        return this;
-    }
-
-
-    public DefaultMemberPermissions getDefaultPermissions() {
-        return defaultPermissions;
-    }
-
-
-    public Command setDefaultPermissions(DefaultMemberPermissions defaultPermissions) {
-        this.defaultPermissions = defaultPermissions;
-        return this;
-    }
-
-
-    public OptionData[] getOptions() {
-        return options;
-    }
-
-
-    public Command addOptions(OptionData... options) {
-        this.options = options;
-        return this;
-    }
-
-
-    public SubcommandData[] getSubcommands() {
-        return subcommands;
-    }
-
-
-    public Command addSubcommands(SubcommandData... subcommands) {
-        this.subcommands = subcommands;
-        return this;
-    }
-
-
-    public SubcommandGroupData[] getSubcommandGroups() {
-        return subcommandGroups;
-    }
-
-
-    public Command addSubcommandGroups(SubcommandGroupData... subcommandGroups) {
-        this.subcommandGroups = subcommandGroups;
-        return this;
-    }
-
-
-    public boolean isNSFW() {
-        return isNSFW;
-    }
-
-
-    public Command setNSFW(boolean isNSFW) {
-        this.isNSFW = isNSFW;
-        return this;
-    }
-
-
-    public InteractionContextType[] getContexts() {
-        return contexts;
-    }
-
-
-    public Command setContexts(InteractionContextType... contexts) {
-        this.contexts = contexts;
-        return this;
-    }
-
-
-    public IntegrationType[] getIntegrationTypes() {
-        return integrationTypes;
-    }
-
-
-    public Command setIntegrationTypes(IntegrationType... integrationTypes) {
-        this.integrationTypes = integrationTypes;
-        return this;
-    }
-
-    
 }

--- a/src/joseta/commands/admin/AdminCommand.java
+++ b/src/joseta/commands/admin/AdminCommand.java
@@ -25,7 +25,7 @@ public class AdminCommand extends Command {
     
     public AdminCommand() {
         super("admin", "Commande administratives.");
-        this.setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MANAGE_SERVER))
+        commandData.setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MANAGE_SERVER))
             .addSubcommandGroups(
                 new SubcommandGroupData("rules", "Catégorie règles")
                     .addSubcommands(

--- a/src/joseta/commands/admin/ConfigCommand.java
+++ b/src/joseta/commands/admin/ConfigCommand.java
@@ -13,7 +13,7 @@ public class ConfigCommand extends Command {
 
     public ConfigCommand() {
         super("config","Configurez les paramètres du bot pour ce serveur.");
-        this.setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MANAGE_SERVER))
+        commandData.setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MANAGE_SERVER))
             .addSubcommands(
                 new SubcommandData("welcome", "Welcome")
                     .addOption(OptionType.BOOLEAN, "enabled", "Enable or disable the welcome join and leave.")

--- a/src/joseta/commands/moderation/BanCommand.java
+++ b/src/joseta/commands/moderation/BanCommand.java
@@ -17,7 +17,7 @@ public class BanCommand extends ModCommand {
     
     public BanCommand() {
         super("ban", "Bannir un membre.");
-        this.setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.BAN_MEMBERS))
+        commandData.setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.BAN_MEMBERS))
             .addOptions(
                 new OptionData(OptionType.USER, "user", "Le membre a bannir.", true),
                 new OptionData(OptionType.STRING, "reason", "La raison du bannisement."),

--- a/src/joseta/commands/moderation/KickCommand.java
+++ b/src/joseta/commands/moderation/KickCommand.java
@@ -13,7 +13,7 @@ public class KickCommand extends ModCommand {
     
     public KickCommand() {
         super("kick", "Exclue du serveur le membre .");
-        this.setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.KICK_MEMBERS))
+        commandData.setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.KICK_MEMBERS))
             .addOptions(
                 new OptionData(OptionType.USER, "user", "Le membre a bannir.", true),
                 new OptionData(OptionType.STRING, "reason", "La raison de l'exclusion.")

--- a/src/joseta/commands/moderation/ModLogCommand.java
+++ b/src/joseta/commands/moderation/ModLogCommand.java
@@ -27,7 +27,7 @@ public class ModLogCommand extends ModCommand {
 
     public ModLogCommand() {
         super("modlog", "Obtient l'historique de modérations d'un membre");
-        this.setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MODERATE_MEMBERS))
+        commandData.setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MODERATE_MEMBERS))
             .addOptions(new OptionData(OptionType.USER, "user", "Le membre pour qui obtenir l'historique."));
     }
 

--- a/src/joseta/commands/moderation/TimeoutCommand.java
+++ b/src/joseta/commands/moderation/TimeoutCommand.java
@@ -15,7 +15,7 @@ public class TimeoutCommand extends ModCommand {
 
     public TimeoutCommand() {
         super("timeout", "Exclue des salons le membre.");
-        this.setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MODERATE_MEMBERS))
+        commandData.setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MODERATE_MEMBERS))
             .addOptions(
                 new OptionData(OptionType.USER, "user", "Le membre a mute.", true),
                 new OptionData(OptionType.STRING, "reason", "La raison du mute."),

--- a/src/joseta/commands/moderation/UnbanCommand.java
+++ b/src/joseta/commands/moderation/UnbanCommand.java
@@ -13,7 +13,7 @@ public class UnbanCommand extends ModCommand {
     
     public UnbanCommand() {
         super("unban", "Débanir un membre.");
-        this.setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.BAN_MEMBERS))
+        commandData.setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.BAN_MEMBERS))
             .addOptions(new OptionData(OptionType.STRING, "user", "L'utilisateur a débanir.", true, true));
     }
 

--- a/src/joseta/commands/moderation/UntimeoutCommand.java
+++ b/src/joseta/commands/moderation/UntimeoutCommand.java
@@ -13,7 +13,7 @@ public class UntimeoutCommand extends ModCommand {
     
     public UntimeoutCommand() {
         super("untimeout", "Retire l'exclusion des salons du membre.");
-        this.setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MODERATE_MEMBERS))
+        commandData.setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MODERATE_MEMBERS))
             .addOptions(new OptionData(OptionType.USER, "user", "Le membre a unmute.", true));
     }
 

--- a/src/joseta/commands/moderation/UnwarnCommand.java
+++ b/src/joseta/commands/moderation/UnwarnCommand.java
@@ -14,7 +14,7 @@ public class UnwarnCommand extends ModCommand {
     
     public UnwarnCommand() {
         super("unwarn", "Retire l'avertissement d'un membre.");
-        this.setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MODERATE_MEMBERS))
+        commandData.setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MODERATE_MEMBERS))
             .addOptions(
                 new OptionData(OptionType.USER, "user", "Le membre a unwarn.", true),
                 new OptionData(OptionType.STRING, "warn_id", "L'identifiant du warn. Plus récent par défaut.", false, true)

--- a/src/joseta/commands/moderation/WarnCommand.java
+++ b/src/joseta/commands/moderation/WarnCommand.java
@@ -12,7 +12,7 @@ public class WarnCommand extends ModCommand {
 
     public WarnCommand() {
         super("warn", "Avertir un membre.");
-        this.setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MODERATE_MEMBERS))
+        commandData.setDefaultPermissions(DefaultMemberPermissions.enabledFor(Permission.MODERATE_MEMBERS))
             .addOptions(
                 new OptionData(OptionType.USER, "user", "Le membre a avertir.", true),
                 new OptionData(OptionType.STRING, "reason", "La raison de l'avertissement."),


### PR DESCRIPTION
Using SlashCommandData directly instead of abstracting over it allows the use by child classes of the full customization potential offered by the JDA library.